### PR TITLE
removed codes affected by deprecation of audio features endpoint

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -2,12 +2,7 @@ export const defaultMetatoolSongMetadata = {
     title: '',
     romTitle: '',
     language: '',
-    timeSignature: '',
-    tempo: 0,
-    durationMinSec: '',
     dateReleased: '',
-    key: -1,
-    mode: -1,
     artist: '',
     initialism: '',
 };

--- a/common/types.ts
+++ b/common/types.ts
@@ -2,12 +2,7 @@ export type MetatoolSongMetadata = {
     title: string;
     romTitle: string;
     language: string;
-    timeSignature: string;
-    tempo: number;
-    durationMinSec: string;
     dateReleased: string;
-    key: number;
-    mode: number;
     artist: string;
     initialism: string;
 };

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -9,14 +9,7 @@ export const deriveMetatoolSongMetadata = (
     romTitle: data.romTitle || '',
     artist: data.artist || '',
     language: data.language || '',
-    timeSignature: data.timeSignature || '',
-    durationMinSec: data.durationMs
-        ? convertDurationMsToMinSec(data.durationMs)
-        : '',
-    tempo: data.tempo || 0,
     dateReleased: data.dateReleased || '',
-    key: data.key === undefined ? -1 : data.key, // key can be 0
-    mode: data.mode === undefined ? -1 : data.mode, // mode can be 0
     initialism: data.initialism || '',
 });
 

--- a/components/MetaToolForm/MetaToolForm.tsx
+++ b/components/MetaToolForm/MetaToolForm.tsx
@@ -5,11 +5,6 @@ import Select, { ValueType } from 'react-select';
 import CopyToClipboardButton from 'components/CopyToClipboardButton';
 
 import { generateMetadataText } from './utils';
-import {
-    convertKeyModeIntToKey,
-    convertKeyToKeyModeInt,
-    convertRelativeKey,
-} from 'common/utils';
 import { MetatoolSongMetadata } from 'common/types';
 import { defaultPinyinSyllableOptions } from './constants';
 import { deriveGoogleSearchLink, deriveGoogleSearchText } from './utils';
@@ -21,14 +16,10 @@ const cx = classnames.bind(styles);
 
 type MetaToolFormProps = {
     metadata: MetatoolSongMetadata;
-    handleMetadataChange: (metadata: MetatoolSongMetadata) => void;
+    handleMetadataChange?: (metadata: MetatoolSongMetadata) => void;
 };
 
-export default function MetaToolForm({
-    metadata,
-    handleMetadataChange,
-}: MetaToolFormProps) {
-    const [originalTempo, setOriginalTempo] = useState(0);
+export default function MetaToolForm({ metadata }: MetaToolFormProps) {
     const [displayedMetadata, setDisplayedMetadata] = useState('');
 
     const [searchLink, setSearchLink] = useState('');
@@ -38,9 +29,7 @@ export default function MetaToolForm({
     const [showPinyin, setShowPinyin] = useState(true);
 
     useEffect(() => {
-        const { title, tempo, language } = metadata;
-
-        setOriginalTempo(tempo);
+        const { title, language } = metadata;
 
         const metaData = generateMetadataText(
             metadata,
@@ -50,33 +39,6 @@ export default function MetaToolForm({
 
         setSearchLink(title ? deriveGoogleSearchLink(title, language) : '');
     }, [metadata, pinyinSyllableOption, showPinyin]);
-
-    function toggleTempoAndTimeSignature() {
-        const updatedMetadata = {
-            ...metadata,
-            tempo:
-                metadata.timeSignature === '12/8'
-                    ? originalTempo * 3
-                    : originalTempo / 3,
-            timeSignature: metadata.timeSignature === '12/8' ? '3/4' : '12/8',
-        };
-
-        handleMetadataChange(updatedMetadata);
-    }
-
-    function toggleRelativeKey() {
-        const keyString = convertKeyModeIntToKey(metadata.key, metadata.mode);
-        const relativeKey = convertRelativeKey(keyString);
-        const [key, mode] = convertKeyToKeyModeInt(relativeKey);
-
-        const updatedMetadata = {
-            ...metadata,
-            key,
-            mode,
-        };
-
-        handleMetadataChange(updatedMetadata);
-    }
 
     function handleChange(selectedOption: ValueType<Option, false>) {
         if (!selectedOption) return;
@@ -127,37 +89,30 @@ export default function MetaToolForm({
                                 metadata.language,
                             )}
                         </a>
-                        <label>
-                            <input
-                                type="checkbox"
-                                onClick={toggleRelativeKey}
-                            />
-                            Relative Key
-                        </label>
                     </>
                 )}
 
-                {(metadata.timeSignature === '3/4' ||
-                    metadata.timeSignature === '12/8') && (
-                    <div className={cx('time-signature-toggle-container')}>
-                        <button
-                            className={cx('toggle', {
-                                selected: metadata.timeSignature === '3/4',
-                            })}
-                            onClick={toggleTempoAndTimeSignature}
-                        >
-                            3/4
-                        </button>
-                        <button
-                            className={cx('toggle', {
-                                selected: metadata.timeSignature === '12/8',
-                            })}
-                            onClick={toggleTempoAndTimeSignature}
-                        >
-                            12/8
-                        </button>
-                    </div>
-                )}
+                {/*{(metadata.timeSignature === '3/4' ||*/}
+                {/*    metadata.timeSignature === '12/8') && (*/}
+                {/*    <div className={cx('time-signature-toggle-container')}>*/}
+                {/*        <button*/}
+                {/*            className={cx('toggle', {*/}
+                {/*                selected: metadata.timeSignature === '3/4',*/}
+                {/*            })}*/}
+                {/*            onClick={toggleTempoAndTimeSignature}*/}
+                {/*        >*/}
+                {/*            3/4*/}
+                {/*        </button>*/}
+                {/*        <button*/}
+                {/*            className={cx('toggle', {*/}
+                {/*                selected: metadata.timeSignature === '12/8',*/}
+                {/*            })}*/}
+                {/*            onClick={toggleTempoAndTimeSignature}*/}
+                {/*        >*/}
+                {/*            12/8*/}
+                {/*        </button>*/}
+                {/*    </div>*/}
+                {/*)}*/}
             </div>
 
             <div>

--- a/components/MetaToolForm/utils.test.ts
+++ b/components/MetaToolForm/utils.test.ts
@@ -5,12 +5,7 @@ const sampleForm: MetatoolSongMetadata = {
     title: '不遗憾',
     romTitle: 'Bu Yi Han',
     artist: 'Ronghao Li',
-    durationMinSec: '5:29',
-    timeSignature: '4/4',
     language: 'mandarin',
-    key: 2,
-    mode: 1,
-    tempo: 66,
     initialism: 'byh',
     dateReleased: '2021-04-10',
     // moods: [{ value: 'sad', label: 'sad' }],
@@ -25,12 +20,7 @@ const sampleForm2: MetatoolSongMetadata = {
     title: '我爱你',
     romTitle: 'Wo Ai Ni',
     artist: 'Crowd Lu',
-    durationMinSec: '4:45',
-    timeSignature: '4/4',
     language: 'mandarin',
-    key: 11,
-    mode: 0,
-    tempo: 93,
     initialism: 'wan',
     dateReleased: '2008-11-10',
     // moods: [{ value: 'sad', label: 'sad' }],
@@ -46,10 +36,10 @@ describe('generateMetaData', () => {
         expect(generateMetadataText(sampleForm, 2)).toBe(
             'Bu Yi 不遗憾\n' +
                 'Ronghao Li\n' +
-                'Key: D\n' +
-                'Tempo: 66\n' +
-                'Duration: 5:29\n' +
-                'Time: 4/4\n' +
+                'Key: \n' +
+                'Tempo: \n' +
+                'Duration: \n' +
+                'Time: \n' +
                 'Keywords: byh, mandarin\n\n' +
                 'Year Released: 2021',
         );
@@ -57,10 +47,10 @@ describe('generateMetaData', () => {
         expect(generateMetadataText(sampleForm2, 1)).toBe(
             'Wo 我爱你\n' +
                 'Crowd Lu\n' +
-                'Key: Bm\n' +
-                'Tempo: 93\n' +
-                'Duration: 4:45\n' +
-                'Time: 4/4\n' +
+                'Key: \n' +
+                'Tempo: \n' +
+                'Duration: \n' +
+                'Time: \n' +
                 'Keywords: wan, mandarin\n\n' +
                 'Year Released: 2008',
         );
@@ -68,10 +58,10 @@ describe('generateMetaData', () => {
         expect(generateMetadataText(sampleForm2, 99)).toBe(
             'Wo Ai Ni 我爱你\n' +
                 'Crowd Lu\n' +
-                'Key: Bm\n' +
-                'Tempo: 93\n' +
-                'Duration: 4:45\n' +
-                'Time: 4/4\n' +
+                'Key: \n' +
+                'Tempo: \n' +
+                'Duration: \n' +
+                'Time: \n' +
                 'Keywords: wan, mandarin\n\n' +
                 'Year Released: 2008',
         );
@@ -84,12 +74,7 @@ describe('generateMetaData', () => {
                     title: '我爱你',
                     romTitle: '',
                     language: '',
-                    timeSignature: '',
-                    tempo: 0,
-                    durationMinSec: '',
                     dateReleased: '',
-                    key: -1,
-                    mode: -1,
                     artist: '',
                     initialism: '',
                 },
@@ -110,12 +95,7 @@ describe('generateMetaData', () => {
                 title: '我爱你',
                 language: 'mandarin',
                 romTitle: '',
-                timeSignature: '',
-                tempo: 0,
-                durationMinSec: '',
                 dateReleased: '',
-                key: -1,
-                mode: -1,
                 artist: '',
                 initialism: '',
             }),
@@ -135,12 +115,7 @@ describe('generateMetaData', () => {
                 initialism: 'wan',
                 romTitle: '',
                 language: '',
-                timeSignature: '',
-                tempo: 0,
-                durationMinSec: '',
                 dateReleased: '',
-                key: -1,
-                mode: -1,
                 artist: '',
             }),
         ).toBe(

--- a/components/MetaToolForm/utils.ts
+++ b/components/MetaToolForm/utils.ts
@@ -1,4 +1,3 @@
-import { convertKeyModeIntToKey } from 'common/utils';
 import { MetatoolSongMetadata } from 'common/types';
 
 // only support mandarin for now, affixes "lyrics" for all other languages
@@ -29,28 +28,12 @@ export function generateMetadataText(
     metadata: MetatoolSongMetadata,
     pinyinSyllableNum = 0,
 ): string {
-    const {
-        title,
-        romTitle,
-        artist,
-        key,
-        mode,
-        tempo,
-        durationMinSec,
-        timeSignature,
-        dateReleased,
-        initialism,
-        language,
-    } = metadata;
+    const { title, romTitle, artist, dateReleased, initialism, language } =
+        metadata;
 
     const displayedPinyin =
         pinyinSyllableNum && romTitle
             ? romTitle.split(' ').slice(0, pinyinSyllableNum).join(' ')
-            : '';
-
-    const keyString =
-        key !== undefined && mode !== undefined
-            ? convertKeyModeIntToKey(key, mode)
             : '';
 
     const yearReleased = dateReleased?.slice(0, 4);
@@ -63,10 +46,10 @@ export function generateMetadataText(
     return (
         `${displayedTitle}\n` +
         (artist ? `${artist}\n` : '') +
-        `Key: ${keyString}\n` +
-        `Tempo: ${tempo || ''}\n` +
-        `Duration: ${durationMinSec || ''}\n` +
-        `Time: ${timeSignature || ''}\n` +
+        `Key: \n` +
+        `Tempo: \n` +
+        `Duration: \n` +
+        `Time: \n` +
         `Keywords: ${displayedKeywords}\n\n` +
         `Year Released: ${yearReleased || ''}`
     );

--- a/pages/api/spotify.api.ts
+++ b/pages/api/spotify.api.ts
@@ -9,13 +9,17 @@ export async function getDataFromSpotify(trackId: string) {
         clientSecret: process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_SECRET,
     });
 
+    console.log(process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID);
+    console.log(process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_SECRET);
     const code = await spotifyApi.clientCredentialsGrant();
     await spotifyApi.setAccessToken(code.body.access_token);
 
-    const data = await spotifyApi.getAudioFeaturesForTrack(trackId);
-    const trackInfo = await spotifyApi.getTrack(trackId);
+    // const data = await spotifyApi.getAudioFeaturesForTrack(trackId);
+    // const data = await spotifyApi.getAudioFeaturesForTrack('test');
 
-    return { audioFeatures: data.body, singleTrack: trackInfo.body };
+    const trackInfo = await spotifyApi.getTrack(trackId);
+    // console.log(trackInfo);
+    return { singleTrack: trackInfo.body };
 }
 
 type ResponseData = {
@@ -34,12 +38,13 @@ export default async function handler(
             return res.status(400).json({ error: 'No track id provided' });
         }
 
-        const { audioFeatures, singleTrack } =
-            await getDataFromSpotify(trackId);
-        const trackInfo = await getAudioFeatures(audioFeatures, singleTrack);
+        console.log(trackId);
+        const { singleTrack } = await getDataFromSpotify(trackId);
+        const trackInfo = await getAudioFeatures(singleTrack);
 
         res.status(200).json({ result: trackInfo });
     } catch (err) {
+        console.log(err);
         res.status(400).json({ error: err });
     }
 }

--- a/pages/repertoire/RepertoireTable/RepertoireRow/EditSongModal/EditSongModal.test.tsx
+++ b/pages/repertoire/RepertoireTable/RepertoireRow/EditSongModal/EditSongModal.test.tsx
@@ -242,10 +242,10 @@ describe('<EditSongModal />', () => {
 
             expect(screen.getByText(/Wo Ai 我爱你/i)).toBeInTheDocument();
             expect(screen.getByText(/Crowd Lu/i)).toBeInTheDocument();
-            expect(screen.getByText(/Key: Bbm/i)).toBeInTheDocument();
-            expect(screen.getByText(/Tempo: 93/i)).toBeInTheDocument();
-            expect(screen.getByText(/Duration: 4:45/i)).toBeInTheDocument();
-            expect(screen.getByText(/Time: 4\/4/i)).toBeInTheDocument();
+            expect(screen.getByText(/Key: /i)).toBeInTheDocument();
+            expect(screen.getByText(/Tempo: /i)).toBeInTheDocument();
+            expect(screen.getByText(/Duration: /i)).toBeInTheDocument();
+            expect(screen.getByText(/Time: /i)).toBeInTheDocument();
             expect(
                 screen.getByText(/Keywords: wan, mandarin/i),
             ).toBeInTheDocument();

--- a/pages/utilities/api/spotify/utils.ts
+++ b/pages/utilities/api/spotify/utils.ts
@@ -6,19 +6,9 @@ export interface TrackData {
     artist: string;
     spotifyLink: string;
     verified: boolean;
-    tempo: number;
     language: string;
-    timeSignature: string;
-    mode: number;
     initialism: string;
-    danceability: number;
-    energy: number;
-    instrumentalness: number;
-    acousticness: number;
-    valence: number;
     dateReleased: string;
-    durationMs: number;
-    key: number;
     romTitle: string;
 }
 
@@ -70,24 +60,9 @@ export function addEnglishTrackInfo(trackData: TrackData) {
 }
 
 export async function getAudioFeatures(
-    data: SpotifyApi.AudioFeaturesResponse,
     trackInfo: SpotifyApi.SingleTrackResponse,
 ) {
     try {
-        console.log(data);
-        const {
-            key,
-            mode,
-            tempo,
-            time_signature,
-            duration_ms,
-            energy,
-            danceability,
-            valence,
-            acousticness,
-            instrumentalness,
-        } = data;
-
         const {
             artists,
             name,
@@ -98,17 +73,7 @@ export async function getAudioFeatures(
         let processedTrackData = {
             title: name,
             artist: artists[0].name,
-            key,
-            mode,
-            tempo: roundTempo(tempo),
             spotifyLink: spotify,
-            durationMs: duration_ms,
-            timeSignature: convertTime(time_signature),
-            energy,
-            danceability,
-            valence,
-            acousticness,
-            instrumentalness,
             verified: false,
             dateReleased: album.release_date,
             romTitle: '',

--- a/pages/utilities/metatool/MetatoolPage.tsx
+++ b/pages/utilities/metatool/MetatoolPage.tsx
@@ -42,20 +42,13 @@ const MetatoolPage: React.FC<MetatoolPageProps> = ({ user }) => {
         });
     }
 
-    const handleMetadataChange = (metadata: MetatoolSongMetadata) => {
-        setMetadata(metadata);
-    };
-
     return (
         <Layout title="Spotify Meta Tool">
             <div className={cx('container')}>
                 <div className={cx('search-bar-container')}>
                     <SpotifySearchBar onSuccess={getFromSpotifyOnSuccess} />
                 </div>
-                <MetaToolForm
-                    metadata={metadata}
-                    handleMetadataChange={handleMetadataChange}
-                />
+                <MetaToolForm metadata={metadata} />
                 {user?.isAdmin && (
                     <div className={cx('checkbox-row-container')}>
                         <input

--- a/pages/utilities/metatool/metatool.test.tsx
+++ b/pages/utilities/metatool/metatool.test.tsx
@@ -184,84 +184,84 @@ describe('The metatool page', () => {
         });
     });
 
-    describe('Toggle time signature feature', () => {
-        const validUrl =
-            'https://open.spotify.com/track/5ioYOfM00Jf3aJBlmecsX7';
-        const songDataInTwelveEight = {
-            title: '深夜',
-            artist: 'Isaac Yong',
-            key: 1,
-            mode: 0,
-            tempo: 171,
-            spotifyLink:
-                'https://open.spotify.com/track/5ioYOfM00Jf3aJBlmecsX7',
-            durationMs: 263390,
-            timeSignature: '3/4',
-            energy: 0.409,
-            danceability: 0.408,
-            valence: 0.279,
-            acousticness: 0.74,
-            instrumentalness: 0,
-            verified: false,
-            dateReleased: '2019-09-19',
-            romTitle: 'Shen Ye',
-            language: 'mandarin',
-            initialism: 'sy',
-        };
-
-        it('should show time signature toggle if time signature is 3/4', async () => {
-            const { searchBar, getFromSpotifyButton } = renderMetaTool();
-
-            mockAxios.post.mockResolvedValueOnce({
-                data: {
-                    result: songDataInTwelveEight,
-                    message: 'This is a mock 222',
-                },
-            });
-
-            userEvent.type(searchBar, validUrl);
-            userEvent.click(getFromSpotifyButton);
-
-            expect(
-                await screen.findByRole('button', { name: '12/8' }),
-            ).toBeInTheDocument();
-            expect(
-                await screen.findByRole('button', { name: '3/4' }),
-            ).toBeInTheDocument();
-        });
-
-        it("should render song's original time signature on button toggle", async () => {
-            const { searchBar, getFromSpotifyButton } = renderMetaTool();
-
-            mockAxios.post.mockResolvedValueOnce({
-                data: {
-                    result: songDataInTwelveEight,
-                    message: 'This is a mock 222',
-                },
-            });
-
-            userEvent.type(searchBar, validUrl);
-            userEvent.click(getFromSpotifyButton);
-
-            const twelveEightButton = await screen.findByRole('button', {
-                name: '12/8',
-            });
-            const threeFourButton = await screen.findByRole('button', {
-                name: '3/4',
-            });
-
-            expect(screen.getByText(/^.*Tempo: 171.*/)).toBeInTheDocument();
-
-            userEvent.click(twelveEightButton);
-            expect(screen.getByText(/^.*Tempo: 57.*/)).toBeInTheDocument();
-
-            userEvent.click(threeFourButton);
-            expect(screen.getByText(/^.*Tempo: 171.*/)).toBeInTheDocument();
-        });
-
-        //contentEditable div not testable at the moment
-        it.todo('should toggle time signature displayed');
-    });
+    // describe('Toggle time signature feature', () => {
+    //     const validUrl =
+    //         'https://open.spotify.com/track/5ioYOfM00Jf3aJBlmecsX7';
+    //     const songDataInTwelveEight = {
+    //         title: '深夜',
+    //         artist: 'Isaac Yong',
+    //         key: 1,
+    //         mode: 0,
+    //         tempo: 171,
+    //         spotifyLink:
+    //             'https://open.spotify.com/track/5ioYOfM00Jf3aJBlmecsX7',
+    //         durationMs: 263390,
+    //         timeSignature: '3/4',
+    //         energy: 0.409,
+    //         danceability: 0.408,
+    //         valence: 0.279,
+    //         acousticness: 0.74,
+    //         instrumentalness: 0,
+    //         verified: false,
+    //         dateReleased: '2019-09-19',
+    //         romTitle: 'Shen Ye',
+    //         language: 'mandarin',
+    //         initialism: 'sy',
+    //     };
+    //
+    //     it('should show time signature toggle if time signature is 3/4', async () => {
+    //         const { searchBar, getFromSpotifyButton } = renderMetaTool();
+    //
+    //         mockAxios.post.mockResolvedValueOnce({
+    //             data: {
+    //                 result: songDataInTwelveEight,
+    //                 message: 'This is a mock 222',
+    //             },
+    //         });
+    //
+    //         userEvent.type(searchBar, validUrl);
+    //         userEvent.click(getFromSpotifyButton);
+    //
+    //         expect(
+    //             await screen.findByRole('button', { name: '12/8' }),
+    //         ).toBeInTheDocument();
+    //         expect(
+    //             await screen.findByRole('button', { name: '3/4' }),
+    //         ).toBeInTheDocument();
+    //     });
+    //
+    //     it("should render song's original time signature on button toggle", async () => {
+    //         const { searchBar, getFromSpotifyButton } = renderMetaTool();
+    //
+    //         mockAxios.post.mockResolvedValueOnce({
+    //             data: {
+    //                 result: songDataInTwelveEight,
+    //                 message: 'This is a mock 222',
+    //             },
+    //         });
+    //
+    //         userEvent.type(searchBar, validUrl);
+    //         userEvent.click(getFromSpotifyButton);
+    //
+    //         const twelveEightButton = await screen.findByRole('button', {
+    //             name: '12/8',
+    //         });
+    //         const threeFourButton = await screen.findByRole('button', {
+    //             name: '3/4',
+    //         });
+    //
+    //         expect(screen.getByText(/^.*Tempo: 171.*/)).toBeInTheDocument();
+    //
+    //         userEvent.click(twelveEightButton);
+    //         expect(screen.getByText(/^.*Tempo: 57.*/)).toBeInTheDocument();
+    //
+    //         userEvent.click(threeFourButton);
+    //         expect(screen.getByText(/^.*Tempo: 171.*/)).toBeInTheDocument();
+    //     });
+    //
+    //     //contentEditable div not testable at the moment
+    //     it.todo('should toggle time signature displayed');
+    // });
 
     describe('The contribution checkbox', () => {
         it('should render if user is logged in as admin', () => {
@@ -300,55 +300,55 @@ describe('The metatool page', () => {
         });
     });
 
-    describe('The relative key checkbox', () => {
-        it('should show only after after clicking Get From Spotify button, with uncheck as default', async () => {
-            const { searchBar, getFromSpotifyButton } = renderMetaTool();
-
-            mockAxios.post.mockResolvedValueOnce({
-                data: {
-                    result: songData,
-                    message: 'This is a mock resolved value',
-                },
-            });
-
-            userEvent.type(searchBar, validUrl);
-            userEvent.click(getFromSpotifyButton);
-
-            const relativeKeyCheckbox = await screen.findByRole('checkbox', {
-                name: /relative key/i,
-            });
-            expect(relativeKeyCheckbox).toBeInTheDocument();
-            expect(relativeKeyCheckbox).not.toBeChecked();
-        });
-
-        it('should be unchecked as default, and toggle check and relative key value when clicked', async () => {
-            const { searchBar, getFromSpotifyButton } = renderMetaTool();
-
-            mockAxios.post.mockResolvedValueOnce({
-                data: {
-                    result: songData,
-                    message: 'This is a mock resolved value',
-                },
-            });
-
-            userEvent.type(searchBar, validUrl);
-            userEvent.click(getFromSpotifyButton);
-
-            const relativeKeyCheckbox = await screen.findByRole('checkbox', {
-                name: /relative key/i,
-            });
-
-            expect(screen.getByText(/^.+Key: D.+/)).toBeInTheDocument();
-
-            userEvent.click(relativeKeyCheckbox);
-            expect(relativeKeyCheckbox).toBeChecked();
-            expect(screen.getByText(/^.+Key: Bm.+/)).toBeInTheDocument();
-
-            userEvent.click(relativeKeyCheckbox);
-            expect(relativeKeyCheckbox).not.toBeChecked();
-            expect(screen.getByText(/^.+Key: D.+/)).toBeInTheDocument();
-        });
-    });
+    // describe('The relative key checkbox', () => {
+    //     it('should show only after after clicking Get From Spotify button, with uncheck as default', async () => {
+    //         const { searchBar, getFromSpotifyButton } = renderMetaTool();
+    //
+    //         mockAxios.post.mockResolvedValueOnce({
+    //             data: {
+    //                 result: songData,
+    //                 message: 'This is a mock resolved value',
+    //             },
+    //         });
+    //
+    //         userEvent.type(searchBar, validUrl);
+    //         userEvent.click(getFromSpotifyButton);
+    //
+    //         const relativeKeyCheckbox = await screen.findByRole('checkbox', {
+    //             name: /relative key/i,
+    //         });
+    //         expect(relativeKeyCheckbox).toBeInTheDocument();
+    //         expect(relativeKeyCheckbox).not.toBeChecked();
+    //     });
+    //
+    //     it('should be unchecked as default, and toggle check and relative key value when clicked', async () => {
+    //         const { searchBar, getFromSpotifyButton } = renderMetaTool();
+    //
+    //         mockAxios.post.mockResolvedValueOnce({
+    //             data: {
+    //                 result: songData,
+    //                 message: 'This is a mock resolved value',
+    //             },
+    //         });
+    //
+    //         userEvent.type(searchBar, validUrl);
+    //         userEvent.click(getFromSpotifyButton);
+    //
+    //         const relativeKeyCheckbox = await screen.findByRole('checkbox', {
+    //             name: /relative key/i,
+    //         });
+    //
+    //         expect(screen.getByText(/^.+Key: D.+/)).toBeInTheDocument();
+    //
+    //         userEvent.click(relativeKeyCheckbox);
+    //         expect(relativeKeyCheckbox).toBeChecked();
+    //         expect(screen.getByText(/^.+Key: Bm.+/)).toBeInTheDocument();
+    //
+    //         userEvent.click(relativeKeyCheckbox);
+    //         expect(relativeKeyCheckbox).not.toBeChecked();
+    //         expect(screen.getByText(/^.+Key: D.+/)).toBeInTheDocument();
+    //     });
+    // });
 
     describe('Copy to Clipboard button', () => {
         it.todo('should copy text in content editable div to clipboard');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3772,7 +3772,7 @@ async-validator@^4.0.2:
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 at-least-node@^1.0.0:
   version "1.0.0"
@@ -5201,7 +5201,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.3.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -5214,6 +5214,13 @@ debug@^3.0.0:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.1.1:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
+  integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
+  dependencies:
+    ms "^2.1.3"
 
 decimal.js@^10.2.1:
   version "10.3.1"
@@ -5291,7 +5298,7 @@ define-property@^2.0.2:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -6405,9 +6412,9 @@ fork-ts-checker-webpack-plugin@^6.0.4:
     tapable "^1.0.0"
 
 form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.2.tgz#83ad9ced7c03feaad97e293d6f6091011e1659c8"
+  integrity sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -9048,7 +9055,19 @@ mime-db@1.48.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
   integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.24:
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
+mime-types@^2.1.27, mime-types@~2.1.24:
   version "2.1.31"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
   integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
@@ -9213,7 +9232,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.1.1:
+ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -9515,9 +9534,9 @@ object-inspect@^1.10.3, object-inspect@^1.9.0:
   integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
 
 object-inspect@^1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
-  integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.3.tgz#f14c183de51130243d6d18ae149375ff50ea488a"
+  integrity sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -10364,9 +10383,9 @@ qs@^6.10.0:
     side-channel "^1.0.4"
 
 qs@^6.9.4:
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.12.0.tgz#edd40c3b823995946a8a0b1f208669c7a200db77"
-  integrity sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.1.tgz#3ce5fc72bd3a8171b85c99b93c65dd20b7d1b16e"
+  integrity sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==
   dependencies:
     side-channel "^1.0.6"
 
@@ -11096,9 +11115,9 @@ read-pkg@^5.2.0:
     util-deprecate "~1.0.1"
 
 readable-stream@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -11576,7 +11595,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.x, semver@^7.2.1, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -11587,6 +11606,11 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.2:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 send@0.17.1:
   version "0.17.1"


### PR DESCRIPTION
https://developer.spotify.com/documentation/web-api/reference/get-audio-features

https://community.spotify.com/t5/Spotify-for-Developers/Changes-to-Web-API/td-p/6540414

Spotify introduced changes to the API, particularly Audio Features resulting in breaking of our app. Unfortunately now our app can't get the the time signature, duration, key and tempo anymore. To circumvent this, we are just going to leave those entries empty. The other metadata will still be in placed